### PR TITLE
Ssid and Pass size fix

### DIFF
--- a/AVRIoT.X/mcc_generated_files/cli/cli.c
+++ b/AVRIoT.X/mcc_generated_files/cli/cli.c
@@ -71,7 +71,7 @@ static bool commandTooLongFlag = false;
 
 const char * const cli_version_number             = "1.0";
 
-const char * const firmware_version_number        = "3.0.0";
+const char * const firmware_version_number        = "3.0.1";
 
 static void command_received(char *command_text);
 static void reset_cmd(char *pArg);
@@ -211,15 +211,15 @@ static void set_wifi_auth(char *ssid_pwd_auth)
     switch (params)
     {
         case WIFI_PARAMS_OPEN:
-                strncpy(ssid, credentials[0],MAX_WIFI_CREDENTIALS_LENGTH-1);
+                strncpy(ssid, credentials[0],M2M_MAX_SSID_LEN);
                 strcpy(pass, "\0");
                 strcpy(authType, "1");                
             break;
 
         case WIFI_PARAMS_PSK:
 		case WIFI_PARAMS_WEP:
-                strncpy(ssid, credentials[0],MAX_WIFI_CREDENTIALS_LENGTH-1);
-                strncpy(pass, credentials[1],MAX_WIFI_CREDENTIALS_LENGTH-1);
+                strncpy(ssid, credentials[0],M2M_MAX_SSID_LEN);
+                strncpy(pass, credentials[1],M2M_MAX_PSK_LEN);
                 sprintf(authType, "%d", params);                
             break;
             

--- a/AVRIoT.X/mcc_generated_files/cli/cli.c
+++ b/AVRIoT.X/mcc_generated_files/cli/cli.c
@@ -71,7 +71,7 @@ static bool commandTooLongFlag = false;
 
 const char * const cli_version_number             = "1.0";
 
-const char * const firmware_version_number        = "3.0.0";
+const char * const firmware_version_number        = "3.0.1";
 
 static void command_received(char *command_text);
 static void reset_cmd(char *pArg);
@@ -211,15 +211,15 @@ static void set_wifi_auth(char *ssid_pwd_auth)
     switch (params)
     {
         case WIFI_PARAMS_OPEN:
-                strncpy(ssid, credentials[0],MAX_WIFI_CREDENTIALS_LENGTH-1);
+                strncpy(ssid, credentials[0],M2M_MAX_SSID_LEN-1);
                 strcpy(pass, "\0");
                 strcpy(authType, "1");                
             break;
 
         case WIFI_PARAMS_PSK:
 		case WIFI_PARAMS_WEP:
-                strncpy(ssid, credentials[0],MAX_WIFI_CREDENTIALS_LENGTH-1);
-                strncpy(pass, credentials[1],MAX_WIFI_CREDENTIALS_LENGTH-1);
+                strncpy(ssid, credentials[0],M2M_MAX_SSID_LEN-1);
+                strncpy(pass, credentials[1],M2M_MAX_PSK_LEN-1);
                 sprintf(authType, "%d", params);                
             break;
             

--- a/AVRIoT.X/mcc_generated_files/cloud/wifi_service.c
+++ b/AVRIoT.X/mcc_generated_files/cloud/wifi_service.c
@@ -206,7 +206,7 @@ bool wifi_connectToAp(uint8_t passed_wifi_creds)
 	
 	if(passed_wifi_creds == NEW_CREDENTIALS)
 	{
-		e=m2m_wifi_connect((char *)ssid, sizeof(ssid), atoi((char*)authType), (char *)pass, M2M_WIFI_CH_ALL);
+		e=m2m_wifi_connect(ssid, strlen(ssid), atoi(authType), pass, M2M_WIFI_CH_ALL);
 	}
 	else
 	{

--- a/AVRIoT.X/mcc_generated_files/cloud/wifi_service.c
+++ b/AVRIoT.X/mcc_generated_files/cloud/wifi_service.c
@@ -206,7 +206,7 @@ bool wifi_connectToAp(uint8_t passed_wifi_creds)
 	
 	if(passed_wifi_creds == NEW_CREDENTIALS)
 	{
-		e=m2m_wifi_connect((char *)ssid, sizeof(ssid), atoi((char*)authType), (char *)pass, M2M_WIFI_CH_ALL);
+		e=m2m_wifi_connect(ssid, strlen(ssid), atoi((char*)authType), pass, M2M_WIFI_CH_ALL);
 	}
 	else
 	{

--- a/AVRIoT.X/mcc_generated_files/cloud/wifi_service.h
+++ b/AVRIoT.X/mcc_generated_files/cloud/wifi_service.h
@@ -31,7 +31,6 @@ SOFTWARE.
 #include <stdint.h>
 #include <stdbool.h>
 
-#define MAX_WIFI_CRED_LENGTH 31
 #define DEFAULT_CREDENTIALS 0
 #define NEW_CREDENTIALS     1
 #define WIFI_SOFT_AP  0

--- a/AVRIoT.X/mcc_generated_files/credentials_storage/credentials_storage.c
+++ b/AVRIoT.X/mcc_generated_files/credentials_storage/credentials_storage.c
@@ -31,8 +31,8 @@
 #include <stdlib.h>
 #include "credentials_storage.h"
 
-char ssid[MAX_WIFI_CREDENTIALS_LENGTH];
-char pass[MAX_WIFI_CREDENTIALS_LENGTH];
+char ssid[M2M_MAX_SSID_LEN];
+char pass[M2M_MAX_PSK_LEN];
 char authType[2];
 char ntpServerName[MAX_NTP_SERVER_LENGTH];
 

--- a/AVRIoT.X/mcc_generated_files/credentials_storage/credentials_storage.h
+++ b/AVRIoT.X/mcc_generated_files/credentials_storage/credentials_storage.h
@@ -29,11 +29,12 @@
 #ifndef CREDENTIALS_STORAGE_H
 #define CREDENTIALS_STORAGE_H
 
-#define MAX_WIFI_CREDENTIALS_LENGTH 31
+#include "winc/m2m/m2m_types.h"
+
 #define MAX_NTP_SERVER_LENGTH	20
 
-extern char ssid[MAX_WIFI_CREDENTIALS_LENGTH];
-extern char pass[MAX_WIFI_CREDENTIALS_LENGTH];
+extern char ssid[M2M_MAX_SSID_LEN];
+extern char pass[M2M_MAX_PSK_LEN];
 extern char authType[2];
 extern char ntpServerName[MAX_NTP_SERVER_LENGTH];
 


### PR DESCRIPTION
Fixes definition of wifi credentials buffers sizes (also avoid duplication) by using the WINC defined (correct) values to allow SSID of full length (32 chars) and passphrases of full size (64). Tested to work with common routers provided by UK fibre service from Virgin and Hyperoptic (example "ACCF Hyperoptic 1Gbps Broadband")